### PR TITLE
fetch headers during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,27 @@ R_HOME=$(shell R RHOME)
 R=$(R_HOME)/bin/R
 RSCRIPT=$(R_HOME)/bin/Rscript
 
+#zmq bacon bits
+ZMQ_VERSION = 4.2.2
+ZMQ_HEADER_TAR_FILE = zmq-${ZMQ_VERSION}-headers.tar.gz
+ZMQ_HEADERS_URL = https://github.com/JuniperKernel/zmq/raw/master/headers/${ZMQ_HEADER_TAR_FILE}
+ZMQ_CPP_HEADER_URL = https://github.com/zeromq/cppzmq/raw/master/zmq.hpp
+ZMQ_CPPADDON_HEADER_URL = https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq_addon.hpp
+
+#quantstack bacon bits
+# xtl
+XTL_VERSION = 0.3.1
+XTL_TAR_FILE = ${XTL_VERSION}.tar.gz
+XTL_URL = https://github.com/QuantStack/xtl/archive/${XTL_TAR_FILE}
+
+# xeus
+XEUS_VERSION = 0.7.0
+XEUS_TAR_FILE = ${XEUS_VERSION}.tar.gz
+XEUS_URL = https://github.com/QuantStack/xeus/archive/${XEUS_TAR_FILE}
+
 default: build/JuniperKernel_$(PKG_VERSION).tar.gz
 
-build/JuniperKernel_$(PKG_VERSION).tar.gz: $(wildcard R/*R) $(wildcard src/*cpp) DESCRIPTION
+build/JuniperKernel_$(PKG_VERSION).tar.gz: $(wildcard R/*R) $(wildcard src/*cpp) DESCRIPTION headers
 	@echo "building " $@ " because " $?
 	@${RSCRIPT} -e 'Rcpp::compileAttributes()'
 	@$(RSCRIPT) -e 'roxygen2::roxygenize()'
@@ -28,6 +46,34 @@ build/JuniperKernel_$(PKG_VERSION).tar.gz: $(wildcard R/*R) $(wildcard src/*cpp)
 #.PHONY: install
 install:
 	R CMD INSTALL --build .
+
+headers: ./inst/include/zmq.h ./inst/include/xtl ./inst/include/xeus
+
+./inst/include/zmq.h:
+	@echo "Fetching zmq headers..."
+	@[ -d ./inst/include ] || mkdir -p ./inst/include
+	@curl -skLO ${ZMQ_CPP_HEADER_URL}
+	@mv zmq.hpp ./inst/include
+	@curl -skLO ${ZMQ_CPPADDON_HEADER_URL}
+	@mv zmq_addon.hpp ./inst/include
+	@curl -skLO ${ZMQ_HEADERS_URL} && tar -xzf ${ZMQ_HEADER_TAR_FILE} && mv include/*h ./inst/include && rm -rf ${ZMQ_HEADER_TAR_FILE} include
+
+./inst/include/xtl:
+	@echo "Fetching xtl headers..."
+	@[ -d ./inst/include ] || mkdir -p ./inst/include
+	@curl -skLO ${XTL_URL}
+	@tar -xzf ${XTL_TAR_FILE}
+	@mv xtl-${XTL_VERSION}/include/xtl ./inst/include
+	@rm -rf xtl-${XTL_VERSION} ${XTL_TAR_FILE}
+
+./inst/include/xeus:
+	@echo "Fetching xeus headers..."
+	@[ -d ./inst/include ] || mkdir -p ./inst/include
+	@curl -skLO ${XEUS_URL}
+	@tar -xzf ${XEUS_TAR_FILE}
+	@mv xeus-${XEUS_VERSION}/include/xeus ./inst/include
+	@rm -rf xeus-${XEUS_VERSION} ${XEUS_TAR_FILE}
+
 
 check: build/JuniperKernel_$(PKG_VERSION).tar.gz
 	@echo "running R CMD check"

--- a/cleanup
+++ b/cleanup
@@ -6,8 +6,6 @@ rm -rf *gz *zip
 rm -rf src/Makevars
 rm -rf src/*dll
 rm -rf inst/zmq
-rm -rf inst/include/zmq*
-rm -rf inst/include/x*
 rm -rf src/*gz
 rm -rf src/._*
 rm -rf src/x64

--- a/cleanup.win
+++ b/cleanup.win
@@ -5,8 +5,6 @@ rm -rf *gz *zip
 rm -rf src/Makevars
 rm -rf src/*dll
 rm -rf inst/zmq
-rm -rf inst/include/zmq*
-rm -rf inst/include/x*
 rm -rf src/*gz
 rm -rf src/._*
 rm -rf src/x64

--- a/configure
+++ b/configure
@@ -11,15 +11,13 @@ SYS=''
 unamestr=`uname`
 if [[ `uname` == 'Linux' ]]; then
    SYS=linux
-   DEPS="deps: lzmq qstack headers"
+   DEPS="deps: lzmq"
    LINKER="-Wl,-R,'\$\$ORIGIN/../zmq'"
 elif [[ `uname` == 'Darwin' ]]; then
    SYS=osx
-   DEPS="deps: zmq qstack"
+   DEPS="deps: zmq"
    LINKER="-Wl,-rpath,${R_LIB}/JuniperKernel/zmq"
 fi
 sed -e"s|@rlib@|"${R_LIB}"|" -e"s|@arch@|"${ARCH}"|" -e"s|@sys@|"${SYS}"|" -e"s/@deps@/${DEPS}/"  -e"s|@LINKER@|"${LINKER}"|" src/Makevars.in > src/Makevars
 
-${RSCRIPT} -e 'Rcpp::compileAttributes()'
-${RSCRIPT} -e 'roxygen2::roxygenize()'
 exit 0

--- a/mk.bat
+++ b/mk.bat
@@ -1,3 +1,45 @@
+:: zmq bacon bits
+set "ZMQ_VERSION=4.2.2"
+set "ZMQ_HEADER_TAR_FILE=zmq-%ZMQ_VERSION%-headers.tar.gz"
+set "ZMQ_HEADERS_URL=https://github.com/JuniperKernel/zmq/raw/master/headers/%ZMQ_HEADER_TAR_FILE%"
+set "ZMQ_CPP_HEADER_URL=https://github.com/zeromq/cppzmq/raw/master/zmq.hpp"
+set "ZMQ_CPPADDON_HEADER_URL=https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq_addon.hpp"
+
+#quantstack bacon bits
+# xtl
+set "XTL_VERSION=0.3.1"
+set "XTL_TAR_FILE=%XTL_VERSION%.tar.gz"
+set "XTL_URL=https://github.com/QuantStack/xtl/archive/%XTL_TAR_FILE%"
+
+# xeus
+set "XEUS_VERSION=0.7.0"
+set "XEUS_TAR_FILE=%XEUS_VERSION%.tar.gz"
+set "XEUS_URL=https://github.com/QuantStack/xeus/archive/%XEUS_TAR_FILE%"
+
+:: fetch headers and put them in inst\include
+if not exist ".\inst\include" mkdir .\inst\include
+
+:: fetch zmq headers
+powershell -Command "Invoke-WebRequest %ZMQ_CPP_HEADER_URL% -OutFile .\inst\include\zmq.hpp"
+powershell -Command "Invoke-WebRequest %ZMQ_CPPADDON_HEADER_URL% -OutFile .\inst\include\zmq_addon.hpp"
+powershell -Command "Invoke-WebRequest %ZMQ_HEADERS_URL% -OutFile %ZMQ_HEADER_TAR_FILE%"
+C:\Rtools\bin\tar -xzf %ZMQ_HEADER_TAR_FILE%
+C:\Rtools\bin\mv include\*h .\inst\include
+C:\Rtools\bin\rm -rf %ZMQ_HEADER_TAR_FILE% include
+
+:: fetch xtl headers
+powershell -Command "Invoke-WebRequest %XTL_URL% -OutFile %XTL_TAR_FILE%"
+C:\Rtools\bin\tar -xzf %XTL_TAR_FILE%
+C:\Rtools\bin\mv xtl-%XTL_VERSION%\include\xtl .\inst\include
+C:\Rtools\bin\rm -rf xtl-%XTL_VERSION% %XTL_TAR_FILE%
+
+
+:: fetch xeus headers
+powershell -Command "Invoke-WebRequest %XEUS_URL% -OutFile %XEUS_TAR_FILE%"
+C:\Rtools\bin\tar -xzf %XTL_TAR_FILE%
+C:\Rtools\bin\mv xeus-%XEUS_VERSION%\include\xeus .\inst\include
+C:\Rtools\bin\rm -rf xeus-%XEUS_VERSION% %XEUS_TAR_FILE%
+
 Rscript -e Rcpp::compileAttributes()
 if %ERRORLEVEL% EQU 1 exit 1
 

--- a/mk.bat
+++ b/mk.bat
@@ -5,13 +5,13 @@ set "ZMQ_HEADERS_URL=https://github.com/JuniperKernel/zmq/raw/master/headers/%ZM
 set "ZMQ_CPP_HEADER_URL=https://github.com/zeromq/cppzmq/raw/master/zmq.hpp"
 set "ZMQ_CPPADDON_HEADER_URL=https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq_addon.hpp"
 
-#quantstack bacon bits
-# xtl
+::quantstack bacon bits
+:: xtl
 set "XTL_VERSION=0.3.1"
 set "XTL_TAR_FILE=%XTL_VERSION%.tar.gz"
 set "XTL_URL=https://github.com/QuantStack/xtl/archive/%XTL_TAR_FILE%"
 
-# xeus
+:: xeus
 set "XEUS_VERSION=0.7.0"
 set "XEUS_TAR_FILE=%XEUS_VERSION%.tar.gz"
 set "XEUS_URL=https://github.com/QuantStack/xeus/archive/%XEUS_TAR_FILE%"
@@ -24,7 +24,7 @@ powershell -Command "Invoke-WebRequest %ZMQ_CPP_HEADER_URL% -OutFile .\inst\incl
 powershell -Command "Invoke-WebRequest %ZMQ_CPPADDON_HEADER_URL% -OutFile .\inst\include\zmq_addon.hpp"
 powershell -Command "Invoke-WebRequest %ZMQ_HEADERS_URL% -OutFile %ZMQ_HEADER_TAR_FILE%"
 C:\Rtools\bin\tar -xzf %ZMQ_HEADER_TAR_FILE%
-C:\Rtools\bin\mv include\*h .\inst\include
+C:\Rtools\bin\mv include/*h .\inst\include
 C:\Rtools\bin\rm -rf %ZMQ_HEADER_TAR_FILE% include
 
 :: fetch xtl headers
@@ -36,7 +36,7 @@ C:\Rtools\bin\rm -rf xtl-%XTL_VERSION% %XTL_TAR_FILE%
 
 :: fetch xeus headers
 powershell -Command "Invoke-WebRequest %XEUS_URL% -OutFile %XEUS_TAR_FILE%"
-C:\Rtools\bin\tar -xzf %XTL_TAR_FILE%
+C:\Rtools\bin\tar -xzf %XEUS_TAR_FILE%
 C:\Rtools\bin\mv xeus-%XEUS_VERSION%\include\xeus .\inst\include
 C:\Rtools\bin\rm -rf xeus-%XEUS_VERSION% %XEUS_TAR_FILE%
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,21 +6,6 @@ R_LIB=@rlib@
 ZMQ_VERSION = 4.2.2
 ZMQ_TAR_FILE= libzmq-${ZMQ_VERSION}.tar.gz
 ZMQ_TAR_URL = https://github.com/JuniperKernel/zmq/raw/master/${SYS}${ARCH}/${ZMQ_TAR_FILE}
-ZMQ_HEADER_TAR_FILE = zmq-${ZMQ_VERSION}-headers.tar.gz
-ZMQ_HEADERS_URL = https://github.com/JuniperKernel/zmq/raw/master/headers/${ZMQ_HEADER_TAR_FILE}
-ZMQ_CPP_HEADER_URL = https://github.com/zeromq/cppzmq/raw/master/zmq.hpp
-ZMQ_CPPADDON_HEADER_URL = https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq_addon.hpp
-
-#quantstack bacon bits
-# xtl
-XTL_VERSION = 0.3.1
-XTL_TAR_FILE = ${XTL_VERSION}.tar.gz
-XTL_URL = https://github.com/QuantStack/xtl/archive/${XTL_TAR_FILE}
-
-# xeus
-XEUS_VERSION = 0.7.0
-XEUS_TAR_FILE = ${XEUS_VERSION}.tar.gz
-XEUS_URL = https://github.com/QuantStack/xeus/archive/${XEUS_TAR_FILE}
 
 ## use C++11
 CXX_STD      = CXX11
@@ -34,7 +19,7 @@ all: deps $(SHLIB)
 @deps@
 
 .PHONY: zmq, lzmq
-zmq: ../inst/zmq/libzmq.a headers
+zmq: ../inst/zmq/libzmq.a
 
 lzmq:
 	@echo "Installing zmq for linux"
@@ -52,32 +37,3 @@ lzmq:
 	@echo "Downloading libzmq prebuild"
 	@[ -d ../inst/zmq ] || mkdir -p ../inst/zmq
 	@curl -skLO ${ZMQ_TAR_URL} && tar -xzf ${ZMQ_TAR_FILE} -C ../inst/zmq && rm -rf ${ZMQ_TAR_FILE}
-
-headers: ../inst/include/zmq.h
-
-../inst/include/zmq.h:
-	@echo "Fetching zmq headers..."
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@curl -skLO ${ZMQ_CPP_HEADER_URL}
-	@mv zmq.hpp ../inst/include
-	@curl -skLO ${ZMQ_CPPADDON_HEADER_URL}
-	@mv zmq_addon.hpp ../inst/include
-	@curl -skLO ${ZMQ_HEADERS_URL} && tar -xzf ${ZMQ_HEADER_TAR_FILE} && mv include/*h ../inst/include && rm -rf ${ZMQ_HEADER_TAR_FILE} include
-
-qstack: ../inst/include/xtl ../inst/include/xeus
-
-../inst/include/xtl:
-	@echo "Fetching xtl headers..."
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@curl -skLO ${XTL_URL}
-	@tar -xzf ${XTL_TAR_FILE}
-	@mv xtl-${XTL_VERSION}/include/xtl ../inst/include
-	@rm -rf xtl-${XTL_VERSION} ${XTL_TAR_FILE}
-
-../inst/include/xeus:
-	@echo "Fetching xeus headers..."
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@curl -skLO ${XEUS_URL}
-	@tar -xzf ${XEUS_TAR_FILE}
-	@mv xeus-${XEUS_VERSION}/include/xeus ../inst/include
-	@rm -rf xeus-${XEUS_VERSION} ${XEUS_TAR_FILE}

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,32 +12,8 @@ PKG_LIBS = -lzmq -L${FLV}
 ZMQ_VERSION = 4.2.2
 ZMQ_TAR_FILE= libzmq-${ZMQ_VERSION}-${FLV}.tar.gz
 ZMQ_TAR_URL = https://github.com/JuniperKernel/zmq/raw/master/win${WIN}/${ZMQ_TAR_FILE}
-ZMQ_HEADER_TAR_FILE = zmq-4.2.2-headers.tar.gz
-ZMQ_HEADERS_URL = https://github.com/JuniperKernel/zmq/raw/master/headers/${ZMQ_HEADER_TAR_FILE}
-ZMQ_CPP_HEADER_URL = https://github.com/zeromq/cppzmq/raw/master/zmq.hpp
-ZMQ_CPPADDON_HEADER_URL = https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq_addon.hpp
 
-# qstack backon bits
-# xeus
-XEUS_VERSION = 0.7.0
-XEUS_TAR_FILE = ${XEUS_VERSION}.tar.gz
-XEUS_URL = https://github.com/QuantStack/xeus/archive/${XEUS_TAR_FILE}
-# xtl
-XTL_VERSION = 0.3.1
-XTL_TAR_FILE = ${XTL_VERSION}.tar.gz
-XTL_URL = https://github.com/QuantStack/xtl/archive/${XTL_TAR_FILE}
-
-all: clean deps $(SHLIB)
-deps: rcpp zmq qstack
-
-rcpp:
-	@echo "Rexe: ${Rexe}"
-	@echo "Generating RcppExports"
-	@Rscript -e 'Rcpp::compileAttributes("..")'
-	@sed -i '/\r/d' ../src/RcppExports.cpp
-	@echo "Moving the generated RcppExports file"
-	@cp ../src/RcppExports.cpp .
-	@Rscript -e 'roxygen2::roxygenize("..")'
+all: clean zmq $(SHLIB)
 
 .Phony: clean
 clean:
@@ -61,34 +37,3 @@ inst/libs/${FLV}/libzmq.dll:
 	#@[ -d ../inst/libs/${FLV} ] || mkdir -p ../inst/libs/${FLV}
 	#@cp ${FLV}/libzmq.dll* ../inst/libs/${FLV}
 	@rm -rf ../inst/libz*
-
-headers: ../inst/include/zmq.h
-../inst/include/zmq.h:
-	@echo "Downloading ZMQ header files"
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@Rscript -e "download.file('${ZMQ_CPP_HEADER_URL}', 'zmq.hpp')"
-	@mv zmq.hpp ../inst/include
-	@Rscript -e "download.file('${ZMQ_CPPADDON_HEADER_URL}', 'zmq_addon.hpp')"
-	@mv zmq_addon.hpp ../inst/include
-	@Rscript -e "download.file('${ZMQ_HEADERS_URL}', '${ZMQ_HEADER_TAR_FILE}')"
-	@tar -xzf ${ZMQ_HEADER_TAR_FILE}
-	@mv include/*h ../inst/include
-	@rm -rf ${ZMQ_HEADER_TAR_FILE} include
-
-qstack: ../inst/include/xeus ../inst/include/xtl
-
-../inst/include/xeus:
-	@echo "Fetching xeus headers..."
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@Rscript -e "download.file('${XEUS_URL}', '${XEUS_TAR_FILE}')"
-	@tar -xzf ${XEUS_TAR_FILE}
-	@mv xeus-${XEUS_VERSION}/include/xeus ../inst/include
-	@rm -rf xeus-${XEUS_VERSION} ${XEUS_TAR_FILE}
-
-../inst/include/xtl:
-	@echo "Fetching xtl headers..."
-	@[ -d ../inst/include ] || mkdir -p ../inst/include
-	@Rscript -e "download.file('${XTL_URL}', '${XTL_TAR_FILE}')"
-	@tar -xzf ${XTL_TAR_FILE}
-	@mv xtl-${XTL_VERSION}/include/xtl ../inst/include
-	@rm -rf xtl-${XTL_VERSION} ${XTL_TAR_FILE}

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -24,7 +24,7 @@ clean:
 	@rm -rf *.o
 
 .Phony: zmq
-zmq: inst/libs/${FLV}/libzmq.dll headers
+zmq: inst/libs/${FLV}/libzmq.dll
 inst/libs/${FLV}/libzmq.dll:
 	@[ -d ../zmq/win/${FLV} ] || mkdir -p ../zmq/win/${FLV}
 	@[ -f ../zmq/win/${FLV}/${ZMQ_TAR_FILE} ] || Rscript -e "download.file('${ZMQ_TAR_URL}', '${ZMQ_TAR_FILE}')"


### PR DESCRIPTION
Start migrating work away from the install step:
1. move headers into build step
2. build libzmq for sources during install step